### PR TITLE
Add olympian stat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ Sample response:
 
 Additionally, the endpoint accepts an optional parameter, `age`, with the values of either `youngest` or `oldest`. When passed, the endpoint will only return the youngest or oldest olympian in the system in the array of olympians.
 
+### GET /api/v1/olympian_stats
+
+Provides statistical information regarding the olympians within the application, including the following information:
+
+- The total count of olympians within the application
+- The average weight of olympians by sex
+- The average age of all olympians
+
+Sample response:
+``` JSON
+{
+  "olympian_stats": {
+    "total_competing_olympians": 3062,
+    "average_weight": {
+      "unit": "kg",
+      "male_olympians": 75.4,
+      "female_olympians": 70.2
+    },
+    "average_age": 26.3
+  }
+}
+```
+
 ## Original Requirements
 
 (Requirements Originally found [here](https://github.com/dionew1/backend-curriculum-site/blob/gh-pages/module4/projects/take_home_challenge/prompts/olympic_spec.md))

--- a/lib/koroibos/olympian.ex
+++ b/lib/koroibos/olympian.ex
@@ -67,6 +67,22 @@ defmodule Koroibos.Olympian do
     )
   end
 
+  @doc """
+  Fetches the statistics for the total count of olympians, average height for olympians by sex, and average age of olympians in the system
+  """
+  @spec all_olympian_stats() :: map()
+  def all_olympian_stats do
+    Repo.one(
+      from o in Olympian,
+      select: %{
+        total_competing_olympians: count(o.id),
+        average_male_weight: fragment("AVG(CASE WHEN ? = ? THEN ? ELSE NULL END)", o.sex, ^0, o.weight),
+        average_female_weight: fragment("AVG(CASE WHEN ? = ? THEN ? ELSE NULL END)", o.sex, ^1, o.weight),
+        average_age: avg(o.age)
+      }
+    )
+  end
+
   # Wrapper function to return the base query used in `all_with_medals/0`, `youngest/0`, and `oldest/0`
   @spec base_olympians_query() :: Ecto.Query
   defp base_olympians_query do

--- a/lib/koroibos_web/controllers/api/v1/olympian_stats_controller.ex
+++ b/lib/koroibos_web/controllers/api/v1/olympian_stats_controller.ex
@@ -4,6 +4,6 @@ defmodule KoroibosWeb.Api.V1.OlympianStatsController do
   alias Koroibos.Olympian
 
   def index(conn, _params) do
-    conn |> render("index.json", Olympian.all_olympian_stats)
+    conn |> render("index.json", %{olympian_stats: Olympian.all_olympian_stats})
   end
 end

--- a/lib/koroibos_web/controllers/api/v1/olympian_stats_controller.ex
+++ b/lib/koroibos_web/controllers/api/v1/olympian_stats_controller.ex
@@ -1,0 +1,9 @@
+defmodule KoroibosWeb.Api.V1.OlympianStatsController do
+  use KoroibosWeb, :controller
+
+  alias Koroibos.Olympian
+
+  def index(conn, _params) do
+    conn |> render("index.json", Olympian.all_olympian_stats)
+  end
+end

--- a/lib/koroibos_web/router.ex
+++ b/lib/koroibos_web/router.ex
@@ -10,6 +10,7 @@ defmodule KoroibosWeb.Router do
 
     scope "/v1", V1, as: :v1 do
       resources "/olympians", OlympianController, only: [:index]
+      get "olympian_stats", OlympianStatsController, :index
     end
   end
 end

--- a/lib/koroibos_web/views/api/v1/olympian_stats_view.ex
+++ b/lib/koroibos_web/views/api/v1/olympian_stats_view.ex
@@ -1,0 +1,21 @@
+defmodule KoroibosWeb.Api.V1.OlympianStatsView do
+  use KoroibosWeb, :view
+
+  alias __MODULE__
+
+  def render("index.json", %{olympian_stats: olympian_stats}) do
+    %{olympian_stats: render_one(olympian_stats, OlympianStatsView, "olympian_stats.json")}
+  end
+
+  def render("olympian_stats.json", %{olympian_stats: olympian_stats}) do
+    %{
+      total_competing_olympians: olympian_stats.total_competing_olympians,
+      average_weight: %{
+        unit: "kg",
+        male_olympians: olympian_stats.average_male_weight,
+        female_olympians: olympian_stats.average_female_weight
+      },
+      average_age: olympian_stats.average_age
+    }
+  end
+end

--- a/test/koroibos_web/controllers/api/v1/olympian_stats_controller_test.exs
+++ b/test/koroibos_web/controllers/api/v1/olympian_stats_controller_test.exs
@@ -14,19 +14,12 @@ defmodule Koroibos.Api.V1.OlympianStatsControllerTest do
     test "Returns the total olympians in the system, along with average weight and age", %{conn: conn} do
       conn = get(conn, "/api/v1/olympian_stats")
 
-      expected = %{
-        "olympian_stats" => %{
-          "total_competing_olympians" => 3,
-          "average_weight" => %{
-            "unit" => "kg",
-            "male_olympians" => 95.0,
-            "female_olympians" => 80.0
-          },
-          "average_age" => 30.0
-        }
-      }
-
-      assert json_response(conn, 200) == expected
+      assert result = json_response(conn, 200)["olympian_stats"]
+      assert result["total_competing_olympians"] == 3
+      assert result["average_weight"]["unit"] == "kg"
+      assert Decimal.eq?(result["average_weight"]["male_olympians"], Decimal.from_float(95.0))
+      assert Decimal.eq?(result["average_weight"]["female_olympians"], Decimal.from_float(80.0))
+      assert Decimal.eq?(result["average_age"], Decimal.from_float(30.0))
     end
   end
 end

--- a/test/koroibos_web/controllers/api/v1/olympian_stats_controller_test.exs
+++ b/test/koroibos_web/controllers/api/v1/olympian_stats_controller_test.exs
@@ -1,0 +1,32 @@
+defmodule Koroibos.Api.V1.OlympianStatsControllerTest do
+  use KoroibosWeb.ConnCase
+
+  alias Koroibos.{Repo, Olympian}
+
+  describe "Olympian Statistics API" do
+    setup do
+      male_olympian_1 = %Olympian{age: 25, weight: 90, sex: :Male} |> Repo.insert!()
+      male_olympian_2 = %Olympian{age: 35, weight: 100, sex: :Male} |> Repo.insert!()
+      female_olympian = %Olympian{age: 30, weight: 80, sex: :Female} |> Repo.insert!()
+      {:ok, male_1: male_olympian_1, male_2: male_olympian_2, female_1: female_olympian}
+    end
+
+    test "Returns the total olympians in the system, along with average weight and age", %{conn: conn} do
+      conn = get(conn, "/api/v1/olympian_stats")
+
+      expected = %{
+        "olympian_stats" => %{
+          "total_competing_olympians" => 3,
+          "average_weight" => %{
+            "unit" => "kg",
+            "male_olympians" => 95.0,
+            "female_olympians" => 80.0
+          },
+          "average_age" => 30.0
+        }
+      }
+
+      assert json_response(conn, 200) == expected
+    end
+  end
+end

--- a/test/olympian_test.exs
+++ b/test/olympian_test.exs
@@ -195,9 +195,9 @@ defmodule Koroibos.OlympianTest do
 
       assert is_map(result)
       assert result.total_competing_olympians == 3
-      assert result.average_male_weight == 95.0
-      assert result.average_female_weight == 80.0
-      assert result.average_age == 30.0
+      assert Decimal.eq?(result.average_male_weight, Decimal.from_float(95.0))
+      assert Decimal.eq?(result.average_female_weight, Decimal.from_float(80.0))
+      assert Decimal.eq?(result.average_age, Decimal.from_float(30.0))
     end
   end
 end

--- a/test/olympian_test.exs
+++ b/test/olympian_test.exs
@@ -181,4 +181,23 @@ defmodule Koroibos.OlympianTest do
       assert result_1.total_medals_won == 0
     end
   end
+
+  describe "Olympian.all_olympian_stats" do
+    setup do
+      male_olympian_1 = %Olympian{age: 25, weight: 90, sex: :Male} |> Repo.insert!()
+      male_olympian_2 = %Olympian{age: 35, weight: 100, sex: :Male} |> Repo.insert!()
+      female_olympian = %Olympian{age: 30, weight: 80, sex: :Female} |> Repo.insert!()
+      {:ok, male_1: male_olympian_1, male_2: male_olympian_2, female_1: female_olympian}
+    end
+
+    test "Returns the count, average age by sex, and average age of all olympians" do
+      result = Olympian.all_olympian_stats
+
+      assert is_map(result)
+      assert result.total_competing_olympians == 3
+      assert result.average_male_weight == 95.0
+      assert result.average_female_weight == 80.0
+      assert result.average_age == 30.0
+    end
+  end
 end


### PR DESCRIPTION
Adds `/api/v1/olympian_stats` endpoint for providing information on the total number of olympians, the average weight by sex, and the average age of the olympians.